### PR TITLE
Restructure and add Undo/Redo functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Latest release is available [here](https://github.com/ryanjsims/hd2-lut-editor/r
 
 You can open a DDS or OpenEXR image via the File menu, or if you run the editor from the command-line you may provide a path to an image to open.
 
-Left click sets the hovered pixel to the current color, and right click selects the hovered pixel's color.
+Left click sets the hovered pixel to the current color, and right click selects the hovered pixel's color. Ctrl-Z to undo, Ctrl-Shift-Z to redo.
 
-If the program crashes, there should be a message about what 
+If the program crashes, there should be a message about what happened in `lut-editor.log` located in the same directory as `lut-editor.exe`.
 
 ## Building
 ### Windows
@@ -22,6 +22,5 @@ If the program crashes, there should be a message about what
 
 ## Future Plans (with no particular ETA)
 
-* Undo/Redo stack
 * Copy/Paste areas of pixels
 * Help window integrating info from the guide

--- a/cmd/lut-editor/main.go
+++ b/cmd/lut-editor/main.go
@@ -226,7 +226,7 @@ func run() {
 			sprite.Draw(win, pixel.IM)
 		}
 
-		nextResponse := showMainMenuBar(img, []bool{channelsVisible, colorVisible, gridVisible})
+		nextResponse := showMainMenuBar(img, channelsVisible, colorVisible, gridVisible)
 		if nextResponse != menuResponseNone {
 			response = nextResponse
 		}
@@ -774,7 +774,7 @@ func newImageDialog(st *newImageStateMachine, windowSize imgui.Vec2) dialogRespo
 	return resp
 }
 
-func showMainMenuBar(img image.Image, visibility []bool) menuResponse {
+func showMainMenuBar(img image.Image, channelsVisible, colorVisible, gridVisible bool) menuResponse {
 	response := menuResponseNone
 	if imgui.BeginMainMenuBar() {
 		if imgui.BeginMenu("File") {
@@ -782,7 +782,7 @@ func showMainMenuBar(img image.Image, visibility []bool) menuResponse {
 			imgui.EndMenu()
 		}
 		if imgui.BeginMenu("View") {
-			response = showViewMenu(visibility)
+			response = showViewMenu(channelsVisible, colorVisible, gridVisible)
 			imgui.EndMenu()
 		}
 		imgui.EndMainMenuBar()
@@ -807,18 +807,15 @@ func showFileMenu(img image.Image) menuResponse {
 	return response
 }
 
-func showViewMenu(visibility []bool) menuResponse {
-	if len(visibility) < 3 {
-		panic(fmt.Errorf("there must be at least 3 visibility bools in the slice"))
-	}
+func showViewMenu(channelsVisible, colorVisible, gridVisible bool) menuResponse {
 	response := menuResponseNone
-	if imgui.MenuItemV("Channels", "", visibility[0], true) {
+	if imgui.MenuItemV("Channels", "", channelsVisible, true) {
 		response = menuResponseViewChannels
 	}
-	if imgui.MenuItemV("Color", "", visibility[1], true) {
+	if imgui.MenuItemV("Color", "", colorVisible, true) {
 		response = menuResponseViewColor
 	}
-	if imgui.MenuItemV("Grid", "", visibility[2], true) {
+	if imgui.MenuItemV("Grid", "", gridVisible, true) {
 		response = menuResponseViewGrid
 	}
 	return response


### PR DESCRIPTION
This is a very simple undo/redo stack, with ctrl-z for undo and ctrl-shift-z for redo. You can also select any undo/redo state on the stack to go back or forwards to. The only thing that clears the undo/redo stack is loading a new image or closing the program, mostly because I'm being lazy about it (but also maybe it could be useful so you don't lose work? idk)